### PR TITLE
feat(blacklist): use SHA1 to query blacklisted passwords

### DIFF
--- a/konker.registry.services.core/src/main/java/com/konkerlabs/platform/registry/business/services/UserServiceImpl.java
+++ b/konker.registry.services.core/src/main/java/com/konkerlabs/platform/registry/business/services/UserServiceImpl.java
@@ -12,11 +12,14 @@ import com.konkerlabs.platform.registry.business.services.api.*;
 import com.konkerlabs.platform.registry.config.EmailConfig;
 import com.konkerlabs.platform.registry.config.PasswordUserConfig;
 import com.konkerlabs.platform.security.managers.PasswordManager;
+
+import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.encoding.ShaPasswordEncoder;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -68,6 +71,7 @@ public class UserServiceImpl implements UserService {
     private PasswordUserConfig passwordUserConfig; 
 
     private PasswordManager passwordManager;
+    
 
     public UserServiceImpl() {
         passwordUserConfig = new PasswordUserConfig(); 
@@ -565,8 +569,13 @@ public class UserServiceImpl implements UserService {
     }
 
     private void validatePasswordBlackList(String password) throws BusinessException {
+        // blacklisted passwords are stored in SHA1 format, because some providers of
+        // leaked passwords publish the database in SHA1 format in order to
+        // protect possible private identifiable information. See haveibeenpwned.com .
+        String hashToBeSearched = DigestUtils.sha1Hex(password).toUpperCase();
+        
         User.PasswordBlacklist matches =
-                passwordBlacklistRepository.findOne(password);
+                passwordBlacklistRepository.findOne(hashToBeSearched);
         if (Optional.ofNullable(matches).isPresent()) {
             throw new BusinessException(Validations.INVALID_PASSWORD_BLACKLISTED.getCode());
         }

--- a/konker.registry.services.core/src/test/java/com/konkerlabs/platform/registry/test/business/services/UserServiceTest.java
+++ b/konker.registry.services.core/src/test/java/com/konkerlabs/platform/registry/test/business/services/UserServiceTest.java
@@ -58,7 +58,7 @@ public class UserServiceTest extends BusinessLayerTestSupport {
     private static final String oldPasswordWrong="password";
     private static final String newPassword="123456789abc$$";
     private static final String newPasswordWrong="123456789abc";
-    private static final String newPasswordblackListed="aaaaaaaaaaaa";
+    private static final String newPasswordblackListed="aaaaaaaaaaaa"; // SHA1 = 384FCD160AB3B33174EA279AD26052EEE191508A
     private static final String newPasswordConfirmation="123456789abc$$";
     private static final String newPasswordConfirmationWrong="abc124$$";
 

--- a/konker.registry.services.core/src/test/resources/fixtures/passwordBlacklist.json
+++ b/konker.registry.services.core/src/test/resources/fixtures/passwordBlacklist.json
@@ -2,6 +2,6 @@
   "passwordBlacklist" : [
     {"_id": "123456789123"},
     {"_id": "123456789012"},
-    {"_id": "aaaaaaaaaaaa"}
+    {"_id": "384FCD160AB3B33174EA279AD26052EEE191508A"}
   ]
 }


### PR DESCRIPTION
blacklisted password should be stored as SHA1, so we will be able to blacklist databases of leaked passwords that are encoded as SHA1 to protect possible personal identifiable information. 