### PR TITLE
add warm up script on rabbit-mq startup

### DIFF
--- a/konker.scripts/docker-demo/Dockerfile
+++ b/konker.scripts/docker-demo/Dockerfile
@@ -72,9 +72,12 @@ RUN yum install -y rabbitmq-server-3.6.10-1.el7.noarch.rpm
 
 #MONGO
 RUN mkdir /etc/mongo
+
 COPY build/mongodb/mongod.conf /etc/default/
 COPY build/mongodb/sleepstart.sh /etc/mongo/
-RUN chmod +x /etc/mongo/sleepstart.sh
+COPY build/rabbitmq/sleepstart.sh /etc/rabbitmq/
+RUN chmod +x /etc/mongo/sleepstart.sh && \
+	chmod +x /etc/rabbitmq/sleepstart.sh
 
 #ENTRYPONT
 COPY docker-entrypoint.sh /

--- a/konker.scripts/docker-demo/build/rabbitmq/sleepstart.sh
+++ b/konker.scripts/docker-demo/build/rabbitmq/sleepstart.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+MAXRETRY=10;
+RETRYCOUNT=0;
+ISRABBITREADY=`nc 127.0.0.1 25672 </dev/null; echo $?`;
+
+while [ $ISRABBITREADY != 0 ]
+do
+  if [ "$ISRABBITREADY" -lt "$MAXRETRY" ]; then
+    ISRABBITREADY=`nc 127.0.0.1 25672 </dev/null; echo $?`;
+    if [ $ISRABBITREADY == 0 ]; then
+      echo 'Konker Message Queue is ready!';
+    else
+      echo "Waiting for konker message queue..."$RETRYCOUNT" of "$MAXRETRY;
+      sleep 10;
+      RETRYCOUNT=$(($RETRYCOUNT+1));
+    fi
+  else
+    sleep 5;
+    ISRABBITREADY=0;
+    echo "Max tries("$MAXRETRY") was reached, Konker message queue is unstable..stop container...";
+    halt;
+  fi
+done

--- a/konker.scripts/docker-demo/docker-entrypoint.sh
+++ b/konker.scripts/docker-demo/docker-entrypoint.sh
@@ -89,6 +89,8 @@ echo "starting RabbitMQ..."
 /usr/sbin/rabbitmq-server &
 service rabbitmq-server status &
 
+/etc/rabbitmq/sleepstart.sh
+
 echo "starting konker registry data ingestion..."
 java -Dconfig.file=/var/lib/jetty/resources/application.conf -jar /var/lib/konker/registry-data.jar --server.port=9090 &
 


### PR DESCRIPTION
If application starts before rabbit-mq (docker-demo for makers container) is ready to receive incoming connections, registry-api fails to start. I just added a warm up script to prevent that error to be shown